### PR TITLE
Fix declare-function usage

### DIFF
--- a/lisp/tr-ime-debug.el
+++ b/lisp/tr-ime-debug.el
@@ -48,7 +48,7 @@
 ;;
 
 (declare-function tr-ime-modadv--set-verbose-level "tr-ime-modadv"
-                  arg1)
+                  (arg1))
 
 (defun tr-ime-debug--verbose-level-set (symb level)
   "デバッグ出力レベルを設定する.

--- a/lisp/tr-ime-documentfeed.el
+++ b/lisp/tr-ime-documentfeed.el
@@ -48,7 +48,7 @@
 ;;
 
 (declare-function tr-ime-modadv--set-documentfeed "tr-ime-modadv"
-                  arg1 arg2)
+                  (arg1 arg2))
 
 (autoload 'tr-ime-reconversion--notify-reconvert-string
   "tr-ime-reconversion")

--- a/lisp/tr-ime-font.el
+++ b/lisp/tr-ime-font.el
@@ -88,7 +88,7 @@ SYMB に slant を指定する。返り値は lfItalic。"
 ;;
 
 (declare-function tr-ime-modadv--set-font "tr-ime-modadv"
-                  arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8)
+                  (arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8))
 (declare-function tr-ime-modadv--get-dpi "tr-ime-modadv")
 
 (defun tr-ime-font-reflect-frame-parameter (&optional frame)

--- a/lisp/tr-ime-isearch.el
+++ b/lisp/tr-ime-isearch.el
@@ -103,8 +103,8 @@
 ;;
 
 (declare-function tr-ime-modadv--set-composition-window "tr-ime-modadv"
-                  arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10
-                  arg11 arg12 arg13 arg14 arg15)
+                  (arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10
+                        arg11 arg12 arg13 arg14 arg15))
 
 (defun tr-ime-isearch--update ()
   "未確定文字列の表示位置を更新・設定する.
@@ -193,7 +193,7 @@ BOOL が non-nil なら \"isearch-mode\" 中の
 
 (declare-function tr-ime-modadv--set-startcomposition-defsubclassproc
                   "tr-ime-modadv"
-                  arg1 arg2)
+                  (arg1 arg2))
 
 (defun tr-ime-isearch--defsubclassproc-set (symb bool)
   "WM_IME_STARTCOMPOSITION で常に DefSubclassProc を呼ぶか否か設定する.

--- a/lisp/tr-ime-openstatus.el
+++ b/lisp/tr-ime-openstatus.el
@@ -67,7 +67,7 @@ IME 状態変更関数 w32-set-ime-open-status を使うが、
   :type 'integer
   :group 'tr-ime-openstatus)
 
-(declare-function w32-set-ime-open-status "w32fns.c" status) ; Emacs 28
+(declare-function w32-set-ime-open-status "w32fns.c" (status)) ; Emacs 28
 (declare-function w32-get-ime-open-status "w32fns.c") ; Emacs 28
 
 (defun tr-ime-openstatus--force-on-emacs28 (&optional _dummy)
@@ -101,9 +101,9 @@ IME が off になる。"
 ;;
 
 (declare-function tr-ime-mod--setopenstatus "tr-ime-mod"
-                  arg1 arg2)
+                  (arg1 arg2))
 (declare-function tr-ime-mod--getopenstatus "tr-ime-mod"
-                  arg1)
+                  (arg1))
 
 (defun tr-ime-openstatus--get-mode-emacs27 ()
   "GNU Emacs 27 standard 向け ime-get-mode 実装.
@@ -134,9 +134,9 @@ IME が off になる。"
 ;;
 
 (declare-function tr-ime-modadv--setopenstatus "tr-ime-modadv"
-                  arg1 arg2)
+                  (arg1 arg2))
 (declare-function tr-ime-modadv--getopenstatus "tr-ime-modadv"
-                  arg1)
+                  (arg1))
 
 (defun tr-ime-openstatus--get-mode-advanced ()
   "Advanced 向け ime-get-mode 実装.

--- a/lisp/tr-ime-prefix-key.el
+++ b/lisp/tr-ime-prefix-key.el
@@ -48,7 +48,7 @@
 ;;
 
 (declare-function tr-ime-modadv--set-prefix-keys "tr-ime-modadv"
-                  arg1 arg2)
+                  (arg1 arg2))
 
 (defvar tr-ime-prefix-key-p t)
 

--- a/lisp/tr-ime-reconversion.el
+++ b/lisp/tr-ime-reconversion.el
@@ -48,7 +48,7 @@
 ;;
 
 (declare-function tr-ime-modadv--notify-reconvert-string "tr-ime-modadv"
-                  arg1 arg2 arg3)
+                  (arg1 arg2 arg3))
 
 (defun tr-ime-reconversion--notify-reconvert-string ()
   "RECONVERTSTRING 構造体用の材料を収集して UI スレッドへ通知する.
@@ -69,7 +69,7 @@ tr-ime-modadv--documentfeed-hook に登録して使う。"
 ;;
 
 (declare-function tr-ime-modadv--set-reconversion "tr-ime-modadv"
-                  arg1 arg2)
+                  (arg1 arg2))
 
 (defun tr-ime-reconversion--set (symb bool)
   "再変換 (RECONVERSION) 動作を行うか否か設定する.

--- a/lisp/tr-ime-subclassify.el
+++ b/lisp/tr-ime-subclassify.el
@@ -54,13 +54,13 @@
 ;;
 
 (declare-function tr-ime-modadv--install-message-hook-hwnd "tr-ime-modadv"
-                  arg1)
+                  (arg1))
 (declare-function tr-ime-modadv--uninstall-message-hook-hwnd "tr-ime-modadv"
-                  arg1)
+                  (arg1))
 (declare-function tr-ime-modadv--subclassify-hwnd "tr-ime-modadv"
-                  arg1 &optional arg2)
+                  (arg1 &optional arg2))
 (declare-function tr-ime-modadv--unsubclassify-hwnd "tr-ime-modadv"
-                  arg1 &optional arg2)
+                  (arg1 &optional arg2))
 
 (defun tr-ime-subclassify--set (symb bool)
   "IME 制御のためメッセージフックしてサブクラス化するか否か設定する.

--- a/lisp/tr-ime-thread-message.el
+++ b/lisp/tr-ime-thread-message.el
@@ -54,7 +54,7 @@
 ;;
 
 (declare-function tr-ime-modadv--set-dispatch-thread-message "tr-ime-modadv"
-                  arg1)
+                  (arg1))
 
 (defun tr-ime-thread-message--dispatch-set (symb bool)
   "スレッドメッセージをディスパッチするか否か設定する.


### PR DESCRIPTION
declare-functionの使い方が違うようだったので修正しました。
https://emacs.stackexchange.com/questions/38219/why-doesnt-this-declare-function-form-suppress-warning-the-function-is-not

しかし、declare-functionの第3引数はこのように記載してもほとんど利
用されないので、特に記載するメリットが分かりません。。

また、同名の関数に2回declare-functionしている箇所があるのですが、
どのような理由でしょうか。。？