### PR TITLE
Remove duplicate tr-ime group definition

### DIFF
--- a/lisp/tr-ime-debug.el
+++ b/lisp/tr-ime-debug.el
@@ -35,10 +35,6 @@
 ;; ユーザ設定用
 ;;
 
-(defgroup tr-ime nil
-  "Emulator of GNU Emacs IME patch for Windows (tr-ime)"
-  :group 'emacs)
-
 (defgroup tr-ime-debug nil
   "デバッグ設定 (advanced)"
   :group 'tr-ime)

--- a/lisp/tr-ime-documentfeed.el
+++ b/lisp/tr-ime-documentfeed.el
@@ -35,10 +35,6 @@
 ;; ユーザ設定用
 ;;
 
-(defgroup tr-ime nil
-  "Emulator of GNU Emacs IME patch for Windows (tr-ime)"
-  :group 'emacs)
-
 (defgroup tr-ime-documentfeed nil
   "前後の確定済文字列を参照した変換 (advanced)"
   :group 'tr-ime)

--- a/lisp/tr-ime-font.el
+++ b/lisp/tr-ime-font.el
@@ -35,10 +35,6 @@
 ;; ユーザ設定用
 ;;
 
-(defgroup tr-ime nil
-  "Emulator of GNU Emacs IME patch for Windows (tr-ime)"
-  :group 'emacs)
-
 (defgroup tr-ime-font nil
   "IME フォント（未確定文字列フォント）設定 (advanced)"
   :group 'tr-ime)

--- a/lisp/tr-ime-hook.el
+++ b/lisp/tr-ime-hook.el
@@ -35,10 +35,6 @@
 ;; ユーザ設定用
 ;;
 
-(defgroup tr-ime nil
-  "Emulator of GNU Emacs IME patch for Windows (tr-ime)"
-  :group 'emacs)
-
 (defgroup tr-ime-core nil
   "コア機能設定
 

--- a/lisp/tr-ime-isearch.el
+++ b/lisp/tr-ime-isearch.el
@@ -35,10 +35,6 @@
 ;; ユーザ設定用
 ;;
 
-(defgroup tr-ime nil
-  "Emulator of GNU Emacs IME patch for Windows (tr-ime)"
-  :group 'emacs)
-
 (defgroup tr-ime-isearch nil
   "isearch-mode 設定 (advanced)"
   :group 'tr-ime)

--- a/lisp/tr-ime-openstatus.el
+++ b/lisp/tr-ime-openstatus.el
@@ -35,10 +35,6 @@
 ;; ユーザ設定用
 ;;
 
-(defgroup tr-ime nil
-  "Emulator of GNU Emacs IME patch for Windows (tr-ime)"
-  :group 'emacs)
-
 (defgroup tr-ime-core nil
   "コア機能設定
 

--- a/lisp/tr-ime-prefix-key.el
+++ b/lisp/tr-ime-prefix-key.el
@@ -35,10 +35,6 @@
 ;; ユーザ設定用
 ;;
 
-(defgroup tr-ime nil
-  "Emulator of GNU Emacs IME patch for Windows (tr-ime)"
-  :group 'emacs)
-
 (defgroup tr-ime-prefix-key nil
   "プレフィックスキー検出 (advanced)"
   :group 'tr-ime)

--- a/lisp/tr-ime-reconversion.el
+++ b/lisp/tr-ime-reconversion.el
@@ -35,10 +35,6 @@
 ;; ユーザ設定用
 ;;
 
-(defgroup tr-ime nil
-  "Emulator of GNU Emacs IME patch for Windows (tr-ime)"
-  :group 'emacs)
-
 (defgroup tr-ime-reconversion nil
   "再変換 (advanced)"
   :group 'tr-ime)

--- a/lisp/tr-ime-recv-notify.el
+++ b/lisp/tr-ime-recv-notify.el
@@ -35,10 +35,6 @@
 ;; ユーザ設定用
 ;;
 
-(defgroup tr-ime nil
-  "Emulator of GNU Emacs IME patch for Windows (tr-ime)"
-  :group 'emacs)
-
 (defgroup tr-ime-core nil
   "コア機能設定
 

--- a/lisp/tr-ime-subclassify.el
+++ b/lisp/tr-ime-subclassify.el
@@ -35,10 +35,6 @@
 ;; ユーザ設定用
 ;;
 
-(defgroup tr-ime nil
-  "Emulator of GNU Emacs IME patch for Windows (tr-ime)"
-  :group 'emacs)
-
 (defgroup tr-ime-core nil
   "コア機能設定
 

--- a/lisp/tr-ime-sync.el
+++ b/lisp/tr-ime-sync.el
@@ -35,10 +35,6 @@
 ;; ユーザ設定用
 ;;
 
-(defgroup tr-ime nil
-  "Emulator of GNU Emacs IME patch for Windows (tr-ime)"
-  :group 'emacs)
-
 (defgroup tr-ime-sync nil
   "IME 状態変更通知による IME/IM 状態同期 (advanced)"
   :group 'tr-ime)

--- a/lisp/tr-ime-thread-message.el
+++ b/lisp/tr-ime-thread-message.el
@@ -35,10 +35,6 @@
 ;; ユーザ設定用
 ;;
 
-(defgroup tr-ime nil
-  "Emulator of GNU Emacs IME patch for Windows (tr-ime)"
-  :group 'emacs)
-
 (defgroup tr-ime-core nil
   "コア機能設定
 

--- a/lisp/tr-ime-workaround-inconsistent.el
+++ b/lisp/tr-ime-workaround-inconsistent.el
@@ -45,10 +45,6 @@
 ;; ユーザ設定用
 ;;
 
-(defgroup tr-ime nil
-  "Emulator of GNU Emacs IME patch for Windows (tr-ime)"
-  :group 'emacs)
-
 (defgroup tr-ime-workaround nil
   "ワークアラウンド設定"
   :group 'tr-ime)

--- a/lisp/tr-ime-workaround-isearch.el
+++ b/lisp/tr-ime-workaround-isearch.el
@@ -35,10 +35,6 @@
 ;; ユーザ設定用
 ;;
 
-(defgroup tr-ime nil
-  "Emulator of GNU Emacs IME patch for Windows (tr-ime)"
-  :group 'emacs)
-
 (defgroup tr-ime-workaround nil
   "ワークアラウンド設定"
   :group 'tr-ime)

--- a/lisp/tr-ime-workaround-prefix-key.el
+++ b/lisp/tr-ime-workaround-prefix-key.el
@@ -43,10 +43,6 @@
 ;; ユーザ設定用
 ;;
 
-(defgroup tr-ime nil
-  "Emulator of GNU Emacs IME patch for Windows (tr-ime)"
-  :group 'emacs)
-
 (defgroup tr-ime-workaround nil
   "ワークアラウンド設定"
   :group 'tr-ime)

--- a/lisp/tr-ime.el
+++ b/lisp/tr-ime.el
@@ -60,6 +60,10 @@
 
 ;;; Code:
 
+(defgroup tr-ime nil
+  "Emulator of GNU Emacs IME patch for Windows (tr-ime)"
+  :group 'emacs)
+
 (defconst tr-ime--mod-abi-version 1
   "ABI version number of tr-ime-mod DLL.")
 (defconst tr-ime--mod-name (concat "tr-ime-mod-"


### PR DESCRIPTION
tr-imeのグループ定義が重複していましたのでメインelispファイルで定
義し、その他のサブElispではサブElispのグループをそれぞれが定義す
ることにしました。

tr-ime-coreについては「通常は変更しないでください」とありますが、
「変更しない」ことを期待するなら、defcustomで宣言せずにdefvarや
defconstで宣言すれば、このようなグループを作らずにすみます。
ユーザーが変更しやすいようにdefcustomで宣言しながら、変更しないでく
ださいというのは矛盾を感じます。

tr-ime-workaroundが重複していますが、分割を解消し、
tr-ime-workaround.elというファイルに入れることで解消できると思い
ます。