### PR TITLE
Fix MSYS2/MinGW-w64 build

### DIFF
--- a/src/get_msg_proc.cc
+++ b/src/get_msg_proc.cc
@@ -25,6 +25,7 @@
 #include "get_msg_proc.hh"
 
 #include <algorithm>
+#include <array>
 #include <atomic>
 #include <future>
 #include <unordered_set>


### PR DESCRIPTION
When I build on MSYS2/MinGW-w64 , it fails.

```
src/get_msg_proc.cc: In static member function 'static bool get_msg_proc::is_target_class(HWND)':
src/get_msg_proc.cc:176:37: error: aggregate 'std::array<wchar_t, 8> buff' has incomplete type and cannot be defined
  176 |   std::array<WCHAR, class_size + 2> buff;
      |                                     ^~~~
make[2]: *** [Makefile:586: get_msg_proc.lo] Error 1
```

I think you need to make src/get_msg_proc.cc explicitly include array C++ header.